### PR TITLE
Fix zipDirectory calling createZip incorrectly.

### DIFF
--- a/iron_worker/iron_worker.py
+++ b/iron_worker/iron_worker.py
@@ -645,7 +645,7 @@ class IronWorker:
         if len(files) < 1:
             return False
 
-        return IronWorker.createZip(files, destination, overwrite)
+        return IronWorker.createZip(destination=destination, files=files, overwrite=overwrite)
 
     @staticmethod
     def getFilenames(directory):


### PR DESCRIPTION
`zipDirectory` was calling `createZip` with the wrong parameter
order. I fixed the order of the caller to most closely match the callee
and made them all named parameters. This will be more future-proof.

Fixes #7.
