### PR TITLE
Change zipDirectory Behaviour

### DIFF
--- a/iron_worker/iron_worker.py
+++ b/iron_worker/iron_worker.py
@@ -659,7 +659,7 @@ class IronWorker:
             return False
 
         return IronWorker.createZip(files=files, destination=destination,
-                        overwrite=overwrite)
+                        overwrite=overwrite, root_dir=directory)
 
     @staticmethod
     def getFilenames(directory):
@@ -672,6 +672,5 @@ class IronWorker:
         names = []
         for dirname, dirnames, filenames in os.walk(directory):
             for filename in filenames:
-                path = dirname.split(os.sep)
-                names.append(os.path.join(os.sep.join(path[1:]), filename))
+                names.append(os.path.join(dirname, filename))
         return names


### PR DESCRIPTION
Change zipDirectory to zip the contents of the directory into the zip's root dir, instead of zipping the directory itself into the zip's root dir.

Will break uploading code for customers who have adapted to the current way of doing things. How can we mitigate that?
