### PR TITLE
Fixed missing requirement 'python-dateutil'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
         py_modules=["iron_worker"],
 	packages=["testDir"],
         version='1.0.1',
-        install_requires=["iron_core"],
+        install_requires=["iron_core", "python-dateutil"],
         description='The Python client for IronWorker, a cloud service for background processing.',
         author='Iron.io',
         author_email="support@iron.io",


### PR DESCRIPTION
Importing iron_worker (e.g. via `from iron_worker import *`) currently yields _ImportError: No module named dateutil.tz_ in [ironworker.py, line 6](https://github.com/iron-io/iron_worker_python/blob/576046ee373247c81aa09a9cfa99466b564c2504/iron_worker.py#L6).

Installing `python-dateutil` manually fixed this, this patch should take care of that automatically.
