### PR TITLE
Update README.md and allow pagination in getting scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ response = worker.queue(task)
 ### Task Options
 
   - **priority**: Setting the priority of your job. Valid values are 0, 1, and 2. The default is 0.
-  - **timeout**: The maximum runtime of your task in seconds. No task can exceed 3600 seconds (60 minutes). The default is 3600 but can be set to a shorter duration.
+  - **timeout**: The maximum runtime of your task in seconds. The default maxium runtime is 3600 seconds (60 minutes), it can be up to 24 hours for Enterprise plans. The default is 3600 but can be set to a different duration.
   - **delay**: The number of seconds to delay before actually queuing the task. Default is 0.
   - **label**: Optional text label for your task. 
   - **cluster**: cluster name ex: "high-mem" or "dedicated".  This is a premium feature for customers to have access to more powerful or custom built worker solutions. Dedicated worker clusters exist for users who want to reserve a set number of workers just for their queued tasks. If not set default is set to  "default" which is the public IronWorker cluster.

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ response = worker.queue(task)
 ### Task Options
 
   - **priority**: Setting the priority of your job. Valid values are 0, 1, and 2. The default is 0.
-  - **timeout**: The maximum runtime of your task in seconds. The default maxium runtime is 3600 seconds (60 minutes), it can be up to 24 hours for Enterprise plans. The default is 3600 but can be set to a different duration.
+  - **timeout**: The maximum runtime of your task in seconds. The default maximum runtime is 3600 seconds (60 minutes), it can be up to 24 hours for Enterprise plans. The default is 3600 but can be set to a different duration.
   - **delay**: The number of seconds to delay before actually queuing the task. Default is 0.
-  - **label**: Optional text label for your task. 
+  - **label**: Optional text label for your task.
   - **cluster**: cluster name ex: "high-mem" or "dedicated".  This is a premium feature for customers to have access to more powerful or custom built worker solutions. Dedicated worker clusters exist for users who want to reserve a set number of workers just for their queued tasks. If not set default is set to  "default" which is the public IronWorker cluster.
 
 

--- a/iron_worker.py
+++ b/iron_worker.py
@@ -370,7 +370,6 @@ class IronWorker:
     ########################## TASKS ############################
     #############################################################
     def tasks(self, scheduled=False, page=None, per_page=30):
-        tasks = []
         if not scheduled:
             resp = self.client.get("tasks")
             raw_tasks = resp["body"]

--- a/iron_worker.py
+++ b/iron_worker.py
@@ -369,19 +369,24 @@ class IronWorker:
     #############################################################
     ########################## TASKS ############################
     #############################################################
-    def tasks(self, scheduled=False):
+    def tasks(self, scheduled=False, page=None, per_page=30):
         tasks = []
         if not scheduled:
             resp = self.client.get("tasks")
             raw_tasks = resp["body"]
             raw_tasks = raw_tasks["tasks"]
         else:
-            resp = self.client.get("schedules")
+            if per_page > 100:
+                raise Exception("The limit for per_page is 100")
+            query_params = "?per_page=" + str(per_page)
+            if page is not None:
+                query_params += "&page=" + page
+            request_string = "schedules" + query_params
+            resp = self.client.get(request_string)
             raw_tasks = resp["body"]
             raw_tasks = raw_tasks["schedules"]
 
-        for raw_task in raw_tasks:
-            tasks.append(Task(raw_task))
+        tasks = [Task(raw_task) for raw_task in raw_tasks]
         return tasks
 
     def tasks_by_code_name(self, code_name):


### PR DESCRIPTION
Two changes:
1) The description is only true for lite, starter, and developer plans. Updated to reflect production and enterprise plans.
2) Allow queries for scheduled tasks by page and specifying page size as specified in the iron api docs