### PR TITLE
Added check for timeout when scheduled=True

### DIFF
--- a/iron_worker.py
+++ b/iron_worker.py
@@ -440,6 +440,8 @@ class IronWorker:
                         task.start_at = task.start_at.replace(tzinfo=tzlocal())
                     task_data["start_at"] = iron_core.IronClient.toRfc3339(
                             task.start_at)
+                if task.timeout is not None:
+                    task_data["timeout"] = task.timeout
                 task_data["label"] = task.label
                 task_data["cluster"] = task.cluster
             tasks_data.append(task_data)

--- a/test.py
+++ b/test.py
@@ -129,7 +129,7 @@ class TestIronWorker(unittest.TestCase):
         resp = self.worker.queue(
                 code_name=self.code_name,
                 payload={"schedule": "AWESOME SCHEDULE!"},
-                start_at=start_at, run_every=3600, run_times=8)
+                start_at=start_at, run_every=3600, run_times=8, timeout=120)
 
         schedules = self.worker.tasks(scheduled=True)
         schedule_ids = []


### PR DESCRIPTION
`timeout` fails to be set properly under the following conditions:

```python
task = Task(code_name="CODE_NAME")
task.scheduled = True
task.label = "JOB_NAME"
task.run_every = 3600
task.priority = 1
task.payload = payload
task.timeout = 60
scheduled_task = self.worker.queue(task)
```
This is due to the fact that `task.timeout` is only set if `scheduled` is `False`. This PR ensures that timeout is set in either case if it's been specified.