### PR TITLE
Python 2/3 compatibility changes

### DIFF
--- a/iron_worker.py
+++ b/iron_worker.py
@@ -579,8 +579,8 @@ class IronWorker:
                 content = f.read()
                 f.close()
                 IronWorker.arguments['payload'] = json.loads(content)
-            except Exception, e:
-                print "Couldn't parse IronWorker payload into json, leaving as string. %s" % e
+            except Exception as e:
+                print("Couldn't parse IronWorker payload into json, leaving as string. %s" % e)
 
         if 'config_file' in IronWorker.arguments and file_exists(IronWorker.arguments['config_file']):
             f = open(IronWorker.arguments['config_file'])
@@ -588,8 +588,8 @@ class IronWorker:
                 content = f.read()
                 f.close()
                 IronWorker.arguments['config'] = json.loads(content)
-            except Exception, e:
-                print "Couldn't parse IronWorker config into json. %s" % e
+            except Exception as e:
+                print("Couldn't parse IronWorker config into json. %s" % e)
 
         IronWorker.isLoaded = True
 

--- a/iron_worker.py
+++ b/iron_worker.py
@@ -393,7 +393,7 @@ class IronWorker:
         resp = self.client.get("tasks?code_name=%s" % code_name)
         raw_tasks = resp["body"]["tasks"]
         for raw_task in raw_tasks:
-           tasks.append(Task(raw_task))
+            tasks.append(Task(raw_task))
         return tasks
 
     def queue(self, task=None, tasks=None, retry=None, **kwargs):

--- a/iron_worker.py
+++ b/iron_worker.py
@@ -481,27 +481,27 @@ class IronWorker:
         headers = {"Accept": "text/plain"}
         resp = self.client.get(url, headers=headers)
         return resp["body"]
-	
+
     def setProgress(self, id, percent, msg=''):
         if isinstance(id, Task):
             id = id.id
         url = "tasks/%s/progress" % id
-	body = {}
-	body['percent'] = percent
-	body['msg'] = msg
+        body = {}
+        body['percent'] = percent
+        body['msg'] = msg
         body = json.dumps(body)
-	resp = self.client.post(url, body=body,
+        resp = self.client.post(url, body=body,
                                     headers={"Content-Type":"application/json"})
         return resp["body"]
-		
+
     def retry(self, id, delay=1):
         if isinstance(id, Task):
             id = id.id
         url = "tasks/%s/retry" % id
-	body = {}
+        body = {}
         body['delay'] = delay
         body = json.dumps(body)
-	resp = self.client.post(url, body=body,
+        resp = self.client.post(url, body=body,
                                     headers={"Content-Type":"application/json"})
         return resp["body"]
 
@@ -574,7 +574,7 @@ class IronWorker:
         if os.getenv('CONFIG_FILE'): IronWorker.arguments['config_file'] = os.getenv('CONFIG_FILE')
 
         if 'payload_file' in IronWorker.arguments and file_exists(IronWorker.arguments['payload_file']):
-	    f = open(IronWorker.arguments['payload_file'], "r")
+            f = open(IronWorker.arguments['payload_file'], "r")
             try:
                 content = f.read()
                 f.close()


### PR DESCRIPTION
There are several tab characters in iron_worker.py.  Python2 interprets a tab as 8 spaces, but Python3 interprets tab as its own whitespace.  When import-ing the module, Python3 throws `TabError: inconsistent use of tabs and spaces in indentation`.  Regardless, mixing tabs and spaces is bad form.

When I dug further, I found deprecated syntax for "except" and "print".  There was also a single line that had an indent of 3 spaces from the block above (instead of 4).