### PR TITLE
Fix a link for the page: IronWorker - How it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 iron_worker_python is Python language binding for IronWorker.
 
 IronWorker is a massively scalable background processing system.
-[See How It Works](http://www.iron.io/products/worker/how).
+[See How It Works](http://www.iron.io/worker/how-it-works/).
 
 # Getting Started
 


### PR DESCRIPTION
Fix a link to the "how it works" page on the GitHub readme