### PR TITLE
Added filter by code_name as a kwarg in IronWorker.tasks(...)

### DIFF
--- a/iron_worker.py
+++ b/iron_worker.py
@@ -417,6 +417,9 @@ class IronWorker:
 
                 query_params.append('to_time=%s' % kwargs['to_time'])
 
+            if 'code_name' in kwargs:
+                query_params.append('code_name=%s' % kwargs['code_name'])
+
             query_params = "&".join(query_params)
             request_string = "tasks?" + query_params
             resp = self.client.get(request_string)


### PR DESCRIPTION
I made some minor modifications to the IronWorker.tasks(...) method to allow a kwarg 'code_name', mirroring the query param in the IronWorker.tasks_by_code_name(...) method. It wasn't until I made my changes that I noticed @cessor had built a very similar PR a few years ago. I think his is better/more conclusive and his tests are great, but obviously requires more significant checking to ensure quality (since it's built on an older version of this package).

Would really appreciate seeing the changes made by either @Cessor or I merged into master!